### PR TITLE
Update for 4.26

### DIFF
--- a/Source/NoesisEditor/Private/NoesisEditorModule.cpp
+++ b/Source/NoesisEditor/Private/NoesisEditorModule.cpp
@@ -292,7 +292,7 @@ public:
 		// Register ticker
 		TickerHandle = FTicker::GetCoreTicker().AddTicker(TEXT("NoesisEditor"), 0.0f, [this](float DeltaTime)
 		{
-			Noesis::GUI::TickInspector();
+			Noesis::GUI::UpdateInspector();
 			return true;
 		});
 	}

--- a/Source/NoesisEditor/Private/NoesisXamlAssetTypeActions.cpp
+++ b/Source/NoesisEditor/Private/NoesisXamlAssetTypeActions.cpp
@@ -182,7 +182,7 @@ void FNoesisXamlAssetTypeActions::AddToViewport(TArray<TWeakObjectPtr<UNoesisXam
 	{
 		FString ViewPackageName, ViewAssetName;
 		AssetToolsModule.Get().CreateUniqueAssetName(PackageRoot + PackagePath, TEXT("View"), ViewPackageName, ViewAssetName);
-		UPackage* ViewPackage = CreatePackage(NULL, *ViewPackageName);
+		UPackage* ViewPackage = CreatePackage(*ViewPackageName);
 		View = CastChecked<UNoesisBlueprint>(FKismetEditorUtilities::CreateBlueprint(UNoesisInstance::StaticClass(), ViewPackage, FName(*ViewAssetName), BPTYPE_Normal, UNoesisBlueprint::StaticClass(), UNoesisBlueprintGeneratedClass::StaticClass(), "UNoesisBlueprintFactory"));
 		View->EnablePPAA = true;
 		FAssetRegistryModule::AssetCreated(View);

--- a/Source/NoesisEditor/Private/NoesisXamlFactory.cpp
+++ b/Source/NoesisEditor/Private/NoesisXamlFactory.cpp
@@ -101,7 +101,7 @@ TArray<UFontFace*> ImportFontFamily(FString PackagePath, FString FamilyName, FSt
 											FT_Done_Face(SubFace);
 											continue;
 										}
-										FontFacePackage = CreatePackage(NULL, *(FontPackagePath / FontFaceName));
+										FontFacePackage = CreatePackage(*(FontPackagePath / FontFaceName));
 
 										auto FontFaceFactory = NewObject<UFontFileImportFactory>();
 										FontFaceFactory->AddToRoot();

--- a/Source/NoesisRuntime/Private/NoesisInstance.cpp
+++ b/Source/NoesisRuntime/Private/NoesisInstance.cpp
@@ -94,7 +94,7 @@ void FNoesisSlateElement::DrawRenderThread(FRHICommandListImmediate& RHICmdList,
 			ETextureCreateFlags TargetableTextureFlags = ETextureCreateFlags::TexCreate_DepthStencilTargetable;
 			FRHIResourceCreateInfo CreateInfo;
 			CreateInfo.ClearValueBinding = FClearValueBinding(0.f, 0);
-			DepthStencilTarget = RHICreateTexture2D(SizeX, SizeY, Format, NumMips, NumSamples, ETextureCreateFlags::TexCreate_DepthStencilTargetable, ERHIAccess::SRVGraphics, CreateInfo);
+			DepthStencilTarget = RHICreateTexture2D(SizeX, SizeY, Format, NumMips, NumSamples, TargetableTextureFlags, ERHIAccess::SRVGraphics, CreateInfo);
 		}
 		// Clear the stencil buffer
 		FRHIRenderPassInfo RPInfo(ColorTarget, ERenderTargetActions::Load_Store, DepthStencilTarget,
@@ -606,7 +606,7 @@ void UNoesisInstance::DrawThumbnail(FIntRect ViewportRect, const FTexture2DRHIRe
 				FRHIResourceCreateInfo CreateInfo;
 				CreateInfo.ClearValueBinding = FClearValueBinding(0.f, 0);
 				FTexture2DRHIRef ColorTarget = BackBuffer;
-				FTexture2DRHIRef DepthStencilTarget = RHICreateTexture2D(SizeX, SizeY, Format, NumMips, NumSamples, ETextureCreateFlags::TexCreate_DepthStencilTargetable, ERHIAccess::SRVGraphics, CreateInfo);
+				FTexture2DRHIRef DepthStencilTarget = RHICreateTexture2D(SizeX, SizeY, Format, NumMips, NumSamples, TargetableTextureFlags, ERHIAccess::SRVGraphics, CreateInfo);
 				FRHIRenderPassInfo RPInfo(ColorTarget, ERenderTargetActions::Load_Store, DepthStencilTarget,
 					MakeDepthStencilTargetActions(ERenderTargetActions::DontLoad_DontStore, ERenderTargetActions::Clear_DontStore), FExclusiveDepthStencil::DepthNop_StencilWrite);
 

--- a/Source/NoesisRuntime/Private/NoesisInstance.cpp
+++ b/Source/NoesisRuntime/Private/NoesisInstance.cpp
@@ -91,7 +91,7 @@ void FNoesisSlateElement::DrawRenderThread(FRHICommandListImmediate& RHICmdList,
 			uint8 Format = (uint8)PF_DepthStencil;
 			uint32 NumMips = 1;
 			uint32 NumSamples = ColorTarget->GetNumSamples();
-			uint32 TargetableTextureFlags = (uint32)TexCreate_DepthStencilTargetable;
+			ETextureCreateFlags TargetableTextureFlags = ETextureCreateFlags::TexCreate_DepthStencilTargetable;
 			FRHIResourceCreateInfo CreateInfo;
 			CreateInfo.ClearValueBinding = FClearValueBinding(0.f, 0);
 			DepthStencilTarget = RHICreateTexture2D(SizeX, SizeY, Format, NumMips, NumSamples, ETextureCreateFlags::TexCreate_DepthStencilTargetable, ERHIAccess::SRVGraphics, CreateInfo);
@@ -602,7 +602,7 @@ void UNoesisInstance::DrawThumbnail(FIntRect ViewportRect, const FTexture2DRHIRe
 				uint8 Format = (uint8)PF_DepthStencil;
 				uint32 NumMips = BackBuffer->GetNumMips();
 				uint32 NumSamples = BackBuffer->GetNumSamples();
-				uint32 TargetableTextureFlags = (uint32)TexCreate_DepthStencilTargetable;
+				ETextureCreateFlags TargetableTextureFlags = ETextureCreateFlags::TexCreate_DepthStencilTargetable;
 				FRHIResourceCreateInfo CreateInfo;
 				CreateInfo.ClearValueBinding = FClearValueBinding(0.f, 0);
 				FTexture2DRHIRef ColorTarget = BackBuffer;

--- a/Source/NoesisRuntime/Private/NoesisInstance.cpp
+++ b/Source/NoesisRuntime/Private/NoesisInstance.cpp
@@ -94,7 +94,7 @@ void FNoesisSlateElement::DrawRenderThread(FRHICommandListImmediate& RHICmdList,
 			uint32 TargetableTextureFlags = (uint32)TexCreate_DepthStencilTargetable;
 			FRHIResourceCreateInfo CreateInfo;
 			CreateInfo.ClearValueBinding = FClearValueBinding(0.f, 0);
-			DepthStencilTarget = RHICreateTexture2D(SizeX, SizeY, Format, NumMips, NumSamples, TargetableTextureFlags, CreateInfo);
+			DepthStencilTarget = RHICreateTexture2D(SizeX, SizeY, Format, NumMips, NumSamples, ETextureCreateFlags::TexCreate_DepthStencilTargetable, ERHIAccess::SRVGraphics, CreateInfo);
 		}
 		// Clear the stencil buffer
 		FRHIRenderPassInfo RPInfo(ColorTarget, ERenderTargetActions::Load_Store, DepthStencilTarget,
@@ -606,7 +606,7 @@ void UNoesisInstance::DrawThumbnail(FIntRect ViewportRect, const FTexture2DRHIRe
 				FRHIResourceCreateInfo CreateInfo;
 				CreateInfo.ClearValueBinding = FClearValueBinding(0.f, 0);
 				FTexture2DRHIRef ColorTarget = BackBuffer;
-				FTexture2DRHIRef DepthStencilTarget = RHICreateTexture2D(SizeX, SizeY, Format, NumMips, NumSamples, TargetableTextureFlags, CreateInfo);
+				FTexture2DRHIRef DepthStencilTarget = RHICreateTexture2D(SizeX, SizeY, Format, NumMips, NumSamples, ETextureCreateFlags::TexCreate_DepthStencilTargetable, ERHIAccess::SRVGraphics, CreateInfo);
 				FRHIRenderPassInfo RPInfo(ColorTarget, ERenderTargetActions::Load_Store, DepthStencilTarget,
 					MakeDepthStencilTargetActions(ERenderTargetActions::DontLoad_DontStore, ERenderTargetActions::Clear_DontStore), FExclusiveDepthStencil::DepthNop_StencilWrite);
 

--- a/Source/NoesisRuntime/Private/NoesisRuntimeModule.cpp
+++ b/Source/NoesisRuntime/Private/NoesisRuntimeModule.cpp
@@ -277,6 +277,8 @@ public:
 		return IsMultiline;
 	}
 
+	virtual bool GetSelection(int& OutSelStart, int& OutSelEnd) { return false; }
+
 private:
 	Noesis::TextBox* TextBox;
 	FString InitialText;
@@ -333,6 +335,8 @@ public:
 	{
 		return false;
 	}
+
+	virtual bool GetSelection(int& OutSelStart, int& OutSelEnd) { return false; }
 
 private:
 	Noesis::PasswordBox* PasswordBox;

--- a/Source/NoesisRuntime/Private/Render/NoesisRenderDevice.cpp
+++ b/Source/NoesisRuntime/Private/Render/NoesisRenderDevice.cpp
@@ -438,10 +438,10 @@ Noesis::Ptr<Noesis::RenderTarget> FNoesisRenderDevice::CreateRenderTarget(const 
 {
 	uint32 NumMips = 1;
 	uint8 Format = (uint8)PF_DepthStencil;
-	uint32 TargetableTextureFlags = (uint32)TexCreate_DepthStencilTargetable;
+	ETextureCreateFlags TargetableTextureFlags = ETextureCreateFlags::TexCreate_DepthStencilTargetable;
 	FRHIResourceCreateInfo CreateInfo;
 	CreateInfo.ClearValueBinding = FClearValueBinding(0.f, 0);
-	FTexture2DRHIRef DepthStencilTarget = RHICreateTexture2D(Width, Height, Format, NumMips, SampleCount, ETextureCreateFlags::TexCreate_DepthStencilTargetable, ERHIAccess::SRVGraphics, CreateInfo);
+	FTexture2DRHIRef DepthStencilTarget = RHICreateTexture2D(Width, Height, Format, NumMips, SampleCount, TargetableTextureFlags, ERHIAccess::SRVGraphics, CreateInfo);
 
 	FName TextureName = FName(Label);
 	DepthStencilTarget->SetName(TextureName);


### PR DESCRIPTION
This update allows this repo to be used following the steps provides in the readme for use with unreal engine 4.26.

Not sure if ERHIAccess::SRVGraphics is correct, but works in my personal projects just fine(and I think it is fine)