### PR TITLE
Minor fix on path to libNoesis.so for Linux

### DIFF
--- a/Source/Noesis/Noesis.Build.cs
+++ b/Source/Noesis/Noesis.Build.cs
@@ -57,7 +57,7 @@ public class Noesis : ModuleRules
 		}
 		else if (Target.Platform == UnrealTargetPlatform.Linux)
 		{
-			PublicAdditionalLibraries.Add(Path.Combine(NoesisBasePath, "Bin", "linunx_x86_64", "libNoesis.so"));
+			PublicAdditionalLibraries.Add(Path.Combine(NoesisBasePath, "Bin", "linux_x86_64", "libNoesis.so"));
 		}
 		else if (Target.Platform == UnrealTargetPlatform.Mac)
 		{


### PR DESCRIPTION
Hi Noesis,

I also hit this error as compiling in Linux, but it is from `NoesisSDK` source:
```
NoesisGUI/Source/Noesis/NoesisSDK/Include/NsCore/TypePropertyUtil.h:90:9: error: member access into incomplete type 'const Noesis::TypeProperty'
    prop->template Set<T>(ptr, DynamicCast<T>(value));
        ^
NoesisGUI/Source/Noesis/NoesisSDK/Include/NsCore/TypeClass.h:22:7: note: forward declaration of 'Noesis::TypeProperty'
class TypeProperty;
      ^
```
So I would think an inclusion of `<NsCore/TypeProperty.h>` is required in `NoesisSDK/Include/NsCore/TypePropertyUtil.h`.